### PR TITLE
Correctly annotate dependency on Net-SSH

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,15 @@
 PATH
   remote: .
   specs:
-    mfi (0.9.0)
+    mfi (0.9.1)
       json (>= 1.8.1)
-      ssh (>= 1.1.0)
+      net-ssh (>= 2.0.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
     json (1.8.1)
-    open4 (1.3.0)
-    ssh (1.1.0)
-      open4 (~> 1.0)
+    net-ssh (2.9.1)
 
 PLATFORMS
   ruby

--- a/mfi.gemspec
+++ b/mfi.gemspec
@@ -14,7 +14,7 @@ spec = Gem::Specification.new do |s|
   s.has_rdoc = true
   
   s.authors = ["Dan Simpson"]
-  s.add_dependency("ssh", ">= 1.1.0")
+  s.add_dependency("net-ssh", ">= 2.0.0")
   s.add_dependency("json", ">= 1.8.1")
 
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
It seems the 'ssh' gem is not used at all, but 'net-ssh' is used instead.
